### PR TITLE
Fix OUTDIR path in matrix workflow

### DIFF
--- a/.github/workflows/resilience-matrix.yml
+++ b/.github/workflows/resilience-matrix.yml
@@ -7,6 +7,8 @@ jobs:
   bench:
     runs-on: ubuntu-22.04
     timeout-minutes: 360
+    env:
+      OUTDIR: DeathStarBench/socialNetwork/results/${{ matrix.mode }}-${{ matrix.fail_fraction }}-${{ matrix.seed }}
     strategy:
       fail-fast: false
       matrix:
@@ -49,12 +51,9 @@ jobs:
           SEED: ${{ matrix.seed }}
           FAIL_FRACTION: ${{ matrix.fail_fraction }}
           P_FAIL: ${{ matrix.fail_fraction }}
-          OUTDIR: DeathStarBench/socialNetwork/results/${{ matrix.mode }}-${{ matrix.fail_fraction }}-${{ matrix.seed }}
         run: |
           chmod +x pipeline_${{ matrix.mode }}.sh
           ./pipeline_${{ matrix.mode }}.sh
-          mkdir -p "$OUTDIR"
-          cp DeathStarBench/socialNetwork/results/${{ matrix.mode }}/*.json "$OUTDIR"/
 
       - name: Upload results
         if: ${{ always() }}
@@ -62,3 +61,4 @@ jobs:
         with:
           name: "${{ matrix.mode }}-${{ matrix.fail_fraction }}-seed${{ matrix.seed }}"
           path: ${{ env.OUTDIR }}/*.json
+          if-no-files-found: error

--- a/pipeline_norepl.sh
+++ b/pipeline_norepl.sh
@@ -3,6 +3,8 @@ set -e
 
 # Optional tunables
 OUTDIR=${OUTDIR:-DeathStarBench/socialNetwork/results/norepl}
+OUTDIR=$(realpath -m "$OUTDIR")
+mkdir -p "$OUTDIR"
 SEED=${SEED:-16}
 P_FAIL=${P_FAIL:-0.30}
 FAIL_FRACTION=${FAIL_FRACTION:-0.30}
@@ -33,3 +35,8 @@ jq -n \
 
 echo "==> Combined summary for NOREPL written to $OUT"
 cat "$OUT"
+
+if ! ls "$OUTDIR"/*.json >/dev/null 2>&1; then
+  echo "❌ No JSON results found in $OUTDIR" >&2
+  exit 1
+fi

--- a/pipeline_repl.sh
+++ b/pipeline_repl.sh
@@ -3,6 +3,8 @@ set -e
 
 # Optional tunables
 OUTDIR=${OUTDIR:-DeathStarBench/socialNetwork/results/repl}
+OUTDIR=$(realpath -m "$OUTDIR")
+mkdir -p "$OUTDIR"
 SEED=${SEED:-16}
 P_FAIL=${P_FAIL:-0.30}
 FAIL_FRACTION=${FAIL_FRACTION:-0.30}
@@ -33,3 +35,8 @@ jq -n \
 
 echo "==> Combined summary for REPL written to $OUT"
 cat "$OUT"
+
+if ! ls "$OUTDIR"/*.json >/dev/null 2>&1; then
+  echo "❌ No JSON results found in $OUTDIR" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- compute `OUTDIR` once per matrix job
- reference the job-level directory in the pipeline step
- ensure missing result files fail the job

## Testing
- `bash -n pipeline_norepl.sh`
- `bash -n pipeline_repl.sh`


------
https://chatgpt.com/codex/tasks/task_e_684d9e8a6fc483318347c8b311cc2bd8